### PR TITLE
merge mobile-friendly-layout

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -112,6 +112,9 @@ p{
 
 h1, h2, h3{
     font-weight: 700;
+    
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
 }
 
 /* HOME PAGE */
@@ -148,16 +151,29 @@ h1, h2, h3{
 
 .question{
 
-    min-width: 50%;
-    max-width: 80%;
+    margin: 5%;
 
-    min-height: 70%;
-    max-height: 100%;
-
-    padding: 0.2vw;
+    padding: 2rem;
 
     border: solid 2px lightgrey;
 
+    display: grid;
+
+}
+
+.question h2, .question h3{
+    text-align: center;
+}
+
+@media screen and (min-width: 1200px){
+
+    .question {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .question .cocktail-name{
+        grid-column: span 2;
+    }
 
 }
 
@@ -183,7 +199,7 @@ h1, h2, h3{
     font-weight: bold;
     background-color: #f5f4f4;
     padding: 0.25vw;
-    margin: 0.25vw;
+   margin: 0.25vw;
 
     border: solid 1px lightgrey;
     border-radius: 0.5vmin;

--- a/css/index.css
+++ b/css/index.css
@@ -184,6 +184,11 @@ h1, h2, h3{
 
 }
 
+.garnish {
+
+    flex-wrap: wrap;
+}
+
 .incorrect{
     color: var(--red);
 }

--- a/js/learn.js
+++ b/js/learn.js
@@ -8,6 +8,12 @@ function createCocktail(name, ingredients, glassName, garnishes, method, idNum){
     q.classList.add("question");
     q.id = "cocktail" + idNum;
 
+    let title = document.createElement("h3");
+    title.innerHTML = name;
+    title.classList.add("cocktail-name");
+
+    q.append(title);
+
     let glass = document.createElement("div");
     glass.classList.add("ver-flex");
     glass.classList.add("center");
@@ -26,10 +32,10 @@ function createCocktail(name, ingredients, glassName, garnishes, method, idNum){
     let info = document.createElement("div");
     info.classList.add("ver-flex");
 
-    let title = document.createElement("h3");
-    title.innerHTML = name;
+    let ingTitle = document.createElement("h3");
+    ingTitle.innerHTML = "Ingredients";
 
-    info.append(title);
+    info.append(ingTitle);
 
     for(j = 0; j < ingredients.length; j++){
 
@@ -51,8 +57,28 @@ function createCocktail(name, ingredients, glassName, garnishes, method, idNum){
 
     }
 
+    let methodTitle = document.createElement("h3");
+    methodTitle.innerHTML = "Method";
+
+    info.append(methodTitle);
+
+    let methodHTML = document.createElement("div");
+    methodHTML.classList.add("hor-flex");
+    methodHTML.classList.add("center");
+
+    methodinput = document.createElement("input");
+    methodinput.setAttribute("type", "text");
+    methodinput.dataset.answer = method.toLowerCase();
+    methodHTML.append(methodinput);
+
+    info.append(methodHTML);
+
+    let garnishTitle = document.createElement("h3");
+    garnishTitle.innerHTML = "Garnishes";
+
+    info.append(garnishTitle);
+
     let garnishesHTML = document.createElement("div");
-    garnishesHTML.innerHTML = "<h5>Garnishes: </h5> ";
     garnishesHTML.classList.add("hor-flex");
 
     for(j = 0; j < garnishes.length; j++){
@@ -66,18 +92,6 @@ function createCocktail(name, ingredients, glassName, garnishes, method, idNum){
     }
 
     info.append(garnishesHTML);
-
-    let methodHTML = document.createElement("div");
-    methodHTML.classList.add("hor-flex");
-    methodHTML.classList.add("space-apart");
-    methodHTML.innerHTML = "<h5>Method: </h5> ";
-
-    methodinput = document.createElement("input");
-    methodinput.setAttribute("type", "text");
-    methodinput.dataset.answer = method.toLowerCase();
-    methodHTML.append(methodinput);
-
-    info.append(methodHTML);
     
     q.append(info);
 
@@ -226,7 +240,7 @@ function NextCocktail(){
         document.getElementById("next-button").innerHTML = "<h4>Back to Home Page</h4>";
     }
 
-    document.getElementById("cocktail"+CURRENT_QUESTION).style.display = "flex";
+    document.getElementById("cocktail"+CURRENT_QUESTION).style.display = "grid";
     document.getElementById("next-button").style.display = "none";
     document.getElementById("check-button").style.display = "block";
 

--- a/js/learn.js
+++ b/js/learn.js
@@ -80,6 +80,7 @@ function createCocktail(name, ingredients, glassName, garnishes, method, idNum){
 
     let garnishesHTML = document.createElement("div");
     garnishesHTML.classList.add("hor-flex");
+    garnishesHTML.classList.add("garnish");
 
     for(j = 0; j < garnishes.length; j++){
 

--- a/js/learn.js
+++ b/js/learn.js
@@ -1,6 +1,94 @@
 var QUANTITY;
 var CURRENT_QUESTION = 0;
 
+function createCocktail(name, ingredients, glassName, garnishes, method, idNum){
+
+    let q = document.createElement("form");
+    q.classList.add("hor-flex");
+    q.classList.add("question");
+    q.id = "cocktail" + idNum;
+
+    let glass = document.createElement("div");
+    glass.classList.add("ver-flex");
+    glass.classList.add("center");
+
+    let glassImg = document.createElement("img");
+    glassImg.src = "img/" + glassName.toLowerCase() + ".png";
+    glass.append(glassImg);
+
+    let glassText = document.createElement("input");
+    glassText.id = "glass";
+    glassText.dataset.answer = glassName.toLowerCase();
+    glass.append(glassText);
+
+    q.append(glass);
+
+    let info = document.createElement("div");
+    info.classList.add("ver-flex");
+
+    let title = document.createElement("h3");
+    title.innerHTML = name;
+
+    info.append(title);
+
+    for(j = 0; j < ingredients.length; j++){
+
+        let ing = document.createElement("div");
+        ing.classList.add("hor-flex");
+        ing.classList.add("space-apart");
+        ing.id = "ingredient" + j;
+
+        let amt = document.createElement("input");
+        amt.id = "ingredient"+j;
+        amt.dataset.answer = ingredients[j].amount;
+        ing.append(amt);
+
+        let ingname = document.createElement("p");
+        ingname.innerHTML = ingredients[j].name
+        ing.append(ingname);
+
+        info.append(ing);
+
+    }
+
+    let garnishesHTML = document.createElement("div");
+    garnishesHTML.innerHTML = "<h5>Garnishes: </h5> ";
+    garnishesHTML.classList.add("hor-flex");
+
+    for(j = 0; j < garnishes.length; j++){
+
+        let g = document.createElement("input");
+        g.dataset.options = garnishes.toString().toLowerCase();
+        g.id = "garnish" + j;
+
+        garnishesHTML.append(g);
+
+    }
+
+    info.append(garnishesHTML);
+
+    let methodHTML = document.createElement("div");
+    methodHTML.classList.add("hor-flex");
+    methodHTML.classList.add("space-apart");
+    methodHTML.innerHTML = "<h5>Method: </h5> ";
+
+    methodinput = document.createElement("input");
+    methodinput.setAttribute("type", "text");
+    methodinput.dataset.answer = method.toLowerCase();
+    methodHTML.append(methodinput);
+
+    info.append(methodHTML);
+    
+    q.append(info);
+
+    if(idNum > 0){
+        q.style.display = "none";
+    }
+
+    return q;
+
+}
+
 async function pageSetup(){
 
     document.getElementById("home-page").style.display = "none";
@@ -23,17 +111,12 @@ async function pageSetup(){
 
     cocktails = cocktails.cocktails;
 
-    console.log(cocktails);
-
     response = await fetch("js/collections.json");
     collections = await response.json();
     collection = collections.collections[collectionid].included // I know it looks like gibberish, it's the collection indicated by the limiter in the array of collections within collections.json
                                                               // Probably needs better name
 
-    console.log(collection)
-
-    var i = 0;
-    for(id = 0; id < cocktails.length; id++){ // For every cocktail in the collection
+    for(id = 0, i = 0; id < cocktails.length; id++, i++){ // For every cocktail in the collection
 
         if(!collection.includes(id)){
             continue; // Only include the ones in the collection
@@ -41,92 +124,15 @@ async function pageSetup(){
 
         cocktail = cocktails[id];
 
-        console.log(id + ": loading " + cocktail.name + "... "); // TODO: remove
-
-        let q = document.createElement("form");
-        q.classList.add("hor-flex");
-        q.classList.add("question");
-        q.id = "cocktail" + i;
-
-        let glass = document.createElement("div");
-        glass.classList.add("ver-flex");
-        glass.classList.add("center");
-
-        let glassImg = document.createElement("img");
-        glassImg.src = "img/" + cocktail.glass.toLowerCase() + ".png";
-        glass.append(glassImg);
-
-        let glassText = document.createElement("input");
-        glassText.id = "glass";
-        glassText.dataset.answer = cocktail.glass.toLowerCase();
-        glass.append(glassText);
-
-        q.append(glass);
-
-        let info = document.createElement("div");
-        info.classList.add("ver-flex");
-
-        let title = document.createElement("h3");
-        title.innerHTML = cocktail.name;
-
-        info.append(title);
-
-        for(j = 0; j < cocktail.ingredients.length; j++){
-
-            let ing = document.createElement("div");
-            ing.classList.add("hor-flex");
-            ing.classList.add("space-apart");
-            ing.id = "ingredient" + j;
-
-            let amt = document.createElement("input");
-            amt.id = "ingredient"+j;
-            amt.dataset.answer = cocktail.ingredients[j].amount;
-            ing.append(amt);
-
-            let ingname = document.createElement("p");
-            ingname.innerHTML = cocktail.ingredients[j].name
-            ing.append(ingname);
-
-            info.append(ing);
-
-        }
-
-        let garnishes = document.createElement("div");
-        garnishes.innerHTML = "<h5>Garnishes: </h5> ";
-        garnishes.classList.add("hor-flex");
-
-        for(j = 0; j < cocktail.garnishes.length; j++){
-
-            let g = document.createElement("input");
-            g.dataset.options = cocktail.garnishes.toString().toLowerCase();
-            g.id = "garnish" + j;
-
-            garnishes.append(g);
-
-        }
-
-        info.append(garnishes);
-
-        let method = document.createElement("div");
-        method.classList.add("hor-flex");
-        method.classList.add("space-apart");
-        method.innerHTML = "<h5>Method: </h5> ";
-
-        methodinput = document.createElement("input");
-        methodinput.setAttribute("type", "text");
-        methodinput.dataset.answer = cocktail.method.toLowerCase();
-        method.append(methodinput);
-
-        info.append(method);
-        
-        q.append(info);
-
-        if(i > 0){
-            q.style.display = "none";
-        }
+        let q = createCocktail(
+            cocktail.name, 
+            cocktail.ingredients, 
+            cocktail.glass, 
+            cocktail.garnishes, 
+            cocktail.method,
+            i);
 
         wrapper.append(q);
-        i++;
     }
 
     let check = document.createElement("button");


### PR DESCRIPTION
Changes:
- Moved question generation to its own function (no other non relevant changes made) for readability
- Added grid display to `.question`: mobile displays as 1 column, screens above 1200 as 2
- Added titles (fixed heading level hierarchy) for ingredients, centred all titles above inputs
- Padding above and below headings altered for better visual grouping
- Changed padding on .question to margin (5%), and changed padding to 2rem all the way round - no more clipping out of the border for more complex cocktails
- Added class to prevent garnishes from clipping when more than 3 are present for a cocktail - also helps with uniformity

All cocktails cycled through on desktop and iPhone SE (browser emulator).